### PR TITLE
Use cache

### DIFF
--- a/indra_wm_service/corpus.py
+++ b/indra_wm_service/corpus.py
@@ -70,13 +70,13 @@ class Corpus(object):
     def __repr__(self):
         return str(self)
 
-    def _get_local_file_key(self, key):
-        """Return local file key path from key
+    def _get_file_key(self, key):
+        """Return file path from key
 
         Parameters
         ----------
         key : str
-            Any of 'cur', 'meta',
+            Any of 'cur', 'meta', 'sts', 'raw'
         Returns
         -------
         str
@@ -313,7 +313,7 @@ class Corpus(object):
             The bucket to upload to. Default: 'world-modelers'.
         """
         # Get curation file key
-        file_key = self._get_local_file_key('cur')
+        file_key = self._get_file_key('cur')
         # First see if we have any curations, then check in cache if
         # look_in_cache == True
         if self.curations:
@@ -335,7 +335,7 @@ class Corpus(object):
 
     def save_curations_to_cache(self):
         """Save current curations to cache"""
-        cur_key = self._get_local_file_key('cur')
+        cur_key = self._get_file_key('cur')
         self._save_to_cache(cur=cur_key)
 
     def get_curations(self, look_in_cache=False):
@@ -354,7 +354,7 @@ class Corpus(object):
         if self.curations:
             curations = self.curations
         elif look_in_cache:
-            file_key = self._get_local_file_key('cur')
+            file_key = self._get_file_key('cur')
             curations = self._load_from_cache(file_key) or {}
         else:
             curations = {}

--- a/indra_wm_service/corpus.py
+++ b/indra_wm_service/corpus.py
@@ -284,7 +284,7 @@ class Corpus(object):
         Parameters
         ----------
         look_in_cache : bool
-            If True, when no curations are avaialbe check if there are
+            If True, when no curations are available check if there are
             curations cached locally. Default: False
         save_to_cache : bool
             If True, also save current curation state to cache. If

--- a/indra_wm_service/corpus.py
+++ b/indra_wm_service/corpus.py
@@ -313,7 +313,13 @@ class Corpus(object):
                               bucket=bucket)
 
         if self.curations and save_to_cache and not look_in_cache:
-            self._save_to_cache(cur=file_key)
+            self.save_curations_to_cache()
+
+    def save_curations_to_cache(self):
+        """Save current curations to cache"""
+        cur_key = '%s/%s/%s.json' % (default_key_base, self.corpus_id,
+                                     file_defaults['cur'])
+        self._save_to_cache(cur=cur_key)
 
     def get_curations(self, look_in_cache=False):
         """Get curations for the corpus

--- a/indra_wm_service/corpus.py
+++ b/indra_wm_service/corpus.py
@@ -69,6 +69,23 @@ class Corpus(object):
     def __repr__(self):
         return str(self)
 
+    def _get_local_file_key(self, key):
+        """Return local file key path from key
+
+        Parameters
+        ----------
+        key : str
+            Any of 'cur', 'meta',
+        Returns
+        -------
+        str
+        """
+        if key not in file_defaults.keys():
+            logger.warning('%s not a recognized file key')
+            return None
+        return '%s/%s/%s.json' % (default_key_base, self.corpus_id,
+                                  file_defaults[key])
+
     @classmethod
     def load_from_s3(cls, corpus_id, aws_name=default_profile,
                      bucket=default_bucket, force_s3_reload=False,
@@ -294,8 +311,7 @@ class Corpus(object):
             The bucket to upload to. Default: 'world-modelers'.
         """
         # Get curation file key
-        file_key = '%s/%s/%s.json' % (default_key_base, self.corpus_id,
-                                      file_defaults['cur'])
+        file_key = self._get_local_file_key('cur')
         # First see if we have any curations, then check in cache if
         # look_in_cache == True
         if self.curations:
@@ -317,8 +333,7 @@ class Corpus(object):
 
     def save_curations_to_cache(self):
         """Save current curations to cache"""
-        cur_key = '%s/%s/%s.json' % (default_key_base, self.corpus_id,
-                                     file_defaults['cur'])
+        cur_key = self._get_local_file_key('cur')
         self._save_to_cache(cur=cur_key)
 
     def get_curations(self, look_in_cache=False):
@@ -337,8 +352,7 @@ class Corpus(object):
         if self.curations:
             curations = self.curations
         elif look_in_cache:
-            file_key = '%s/%s/%s.json' % (default_key_base, self.corpus_id,
-                                          file_defaults['cur'])
+            file_key = self._get_local_file_key('cur')
             curations = self._load_from_cache(file_key) or {}
         else:
             curations = {}

--- a/indra_wm_service/corpus.py
+++ b/indra_wm_service/corpus.py
@@ -16,14 +16,20 @@ class Corpus(object):
 
     Parameters
     ----------
+    corpus_id : str
+        The key by which the corpus is identified.
     statements : list[indra.statement.Statement]
         A list of INDRA Statements to embed in the corpus.
     raw_statements : list[indra.statement.Statement]
         A List of raw statements forming the basis of the statements in
         'statements'.
+    meta_data : dict
+        A dict with meta data associated with the corpus
     aws_name : str
         The name of the profile in the AWS credential file to use. 'default' is
         used by default.
+    cache : Pathlib.path
+        A Pathlib.path object representing the path to a cache folder.
 
     Attributes
     ----------
@@ -34,8 +40,6 @@ class Corpus(object):
     curations : dict
         A dict keeping track of the curations submitted so far for Statement
         UUIDs in the corpus.
-    meta_data : dict
-        A dict with meta data associated with the corpus
     """
     def __init__(self, corpus_id, statements=None, raw_statements=None,
                  meta_data=None, aws_name=default_profile, cache=CACHE):
@@ -77,11 +81,13 @@ class Corpus(object):
         ----------
         key : str
             Any of 'cur', 'meta', 'sts', 'raw'
+
         Returns
         -------
         str
+            The S3 key for the given file.
         """
-        if key not in file_defaults.keys():
+        if key not in file_defaults:
             logger.warning('%s not a recognized file key')
             return None
         return '%s/%s/%s.json' % (default_key_base, self.corpus_id,

--- a/indra_wm_service/curator.py
+++ b/indra_wm_service/curator.py
@@ -133,8 +133,8 @@ class LiveCurator(object):
             A dict of curations with keys corresponding to Statement UUIDs and
             values corresponding to correct/incorrect feedback.
         save : bool
-            If True, save the updated curations to the local cache as well
-            as to s3. Default: True
+            If True, save the updated curations to the local cache.
+            Default: True
         """
         logger.info('Submitting curations for corpus "%s"' % corpus_id)
         corpus = self.get_corpus(corpus_id, check_s3=True, use_cache=True)
@@ -180,7 +180,7 @@ class LiveCurator(object):
 
         # Save the updated curations to S3 and cache
         if save:
-            self.save_curation(corpus_id, save_to_cache=True)
+            corpus.save_curations_to_cache()
 
     def save_curation(self, corpus_id, save_to_cache=True):
         """Save the current state of curations for a corpus given its ID

--- a/indra_wm_service/curator.py
+++ b/indra_wm_service/curator.py
@@ -4,7 +4,7 @@ from indra.belief.wm_scorer import get_eidos_bayesian_scorer
 from indra.sources.eidos import reground_texts
 from indra.tools import assemble_corpus as ac
 from indra.belief import BeliefEngine
-from . import file_defaults, default_key_base, InvalidCorpusError
+from . import file_defaults, default_key_base, InvalidCorpusError, CACHE
 from .corpus import Corpus
 
 logger = logging.getLogger(__name__)
@@ -22,11 +22,12 @@ class LiveCurator(object):
     """
 
     def __init__(self, scorer=None, corpora=None, eidos_url=None,
-                 ont_manager=None):
+                 ont_manager=None, cache=CACHE):
         self.corpora = corpora if corpora else {}
         self.scorer = scorer if scorer else get_eidos_bayesian_scorer()
         self.ont_manager = ont_manager
         self.eidos_url = eidos_url
+        self.cache = cache
 
     # TODO: generalize this to other kinds of scorers
     def reset_scorer(self):
@@ -67,6 +68,7 @@ class LiveCurator(object):
             corpus = Corpus.load_from_s3(corpus_id,
                                          force_s3_reload=not use_cache,
                                          raise_exc=True)
+            corpus.cache = self.cache
             logger.info('Adding corpus to loaded corpora')
             self.corpora[corpus_id] = corpus
 

--- a/indra_wm_service/curator.py
+++ b/indra_wm_service/curator.py
@@ -122,7 +122,7 @@ class LiveCurator(object):
                                    curated_stmts.items()}}
         return data
 
-    def submit_curation(self, corpus_id, curations):
+    def submit_curation(self, corpus_id, curations, save=True):
         """Submit correct/incorrect curations fo a given corpus.
 
         Parameters
@@ -132,6 +132,9 @@ class LiveCurator(object):
         curations : dict
             A dict of curations with keys corresponding to Statement UUIDs and
             values corresponding to correct/incorrect feedback.
+        save : bool
+            If True, save the updated curations to the local cache as well
+            as to s3. Default: True
         """
         logger.info('Submitting curations for corpus "%s"' % corpus_id)
         corpus = self.get_corpus(corpus_id, check_s3=True, use_cache=True)
@@ -174,6 +177,10 @@ class LiveCurator(object):
                             += 1
         # Finally, we update the scorer with the new curation counts
         self.scorer.update_counts(prior_counts, subtype_counts)
+
+        # Save the updated curations to S3 and cache
+        if save:
+            self.save_curation(corpus_id, save_to_cache=True)
 
     def save_curation(self, corpus_id, save_to_cache=True):
         """Save the current state of curations for a corpus given its ID

--- a/indra_wm_service/live_curation.py
+++ b/indra_wm_service/live_curation.py
@@ -258,7 +258,7 @@ if __name__ == '__main__':
         logger.info(f'Changing local cache to provided path {args.cache}')
         cache = Path(args.cache)
         cache.mkdir(exist_ok=True)
-        CACHE = cache
+        curator.cache = cache
     else:
         logger.info(f'Using local cache {CACHE}')
 

--- a/indra_wm_service/live_curation.py
+++ b/indra_wm_service/live_curation.py
@@ -200,7 +200,7 @@ if __name__ == '__main__':
     parser.add_argument('--pickle')
     parser.add_argument('--meta-json', help='Meta data json file')
     parser.add_argument('--corpus_id')
-    parser.add_argument('--cache')
+    parser.add_argument('--cache', help='Override the default local cache')
     parser.add_argument('--host', default='0.0.0.0')
     parser.add_argument('--eidos-url', default='http://localhost:9000')
     parser.add_argument('--port', default=8001, type=int)

--- a/indra_wm_service/live_curation.py
+++ b/indra_wm_service/live_curation.py
@@ -4,11 +4,12 @@ import pickle
 import logging
 import argparse
 from os import path
+from pathlib import Path
 from flask import Flask, request, jsonify, abort, Response
 from indra.statements import stmts_from_json_file, stmts_to_json
 from indra.ontology.world.ontology import world_ontology
 
-from . import InvalidCorpusError
+from . import InvalidCorpusError, CACHE
 from .corpus import Corpus
 from .curator import LiveCurator
 from .util import _json_loader
@@ -199,6 +200,7 @@ if __name__ == '__main__':
     parser.add_argument('--pickle')
     parser.add_argument('--meta-json', help='Meta data json file')
     parser.add_argument('--corpus_id')
+    parser.add_argument('--cache')
     parser.add_argument('--host', default='0.0.0.0')
     parser.add_argument('--eidos-url', default='http://localhost:9000')
     parser.add_argument('--port', default=8001, type=int)
@@ -251,6 +253,14 @@ if __name__ == '__main__':
             curator.corpora[args.corpus_id] = Corpus(stmts, raw_stmts,
                                                      meta_json_obj,
                                                      args.aws_cred)
+
+    if args.cache:
+        logger.info(f'Changing local cache to provided path {args.cache}')
+        cache = Path(args.cache)
+        cache.mkdir(exist_ok=True)
+        CACHE = cache
+    else:
+        logger.info(f'Using local cache {CACHE}')
 
     # Run the app
     app.run(host=args.host, port=args.port, threaded=False)

--- a/indra_wm_service/live_curation.py
+++ b/indra_wm_service/live_curation.py
@@ -74,7 +74,7 @@ def submit_curation():
     corpus_id = request.json.get('corpus_id')
     curations = request.json.get('curations', {})
     try:
-        curator.submit_curation(corpus_id, curations)
+        curator.submit_curation(corpus_id, curations, save=True)
     except InvalidCorpusError:
         abort(Response('The corpus_id "%s" is unknown.' % corpus_id, 400))
         return


### PR DESCRIPTION
This PR updates the cache capabilities of the live curation service. The local cache directory is now an attribute of the Corpus and Curator classes and can be set when starting the service:
`python -m indra.tools.live_curation.live_curation --cache /sw/mounted/live_curator_cache`

This makes using a custom cache directory much easier and also makes it possible to save the cache in a mounted directory when running the service from a docker container in order to persist the cache after stopping the docker.

The service is also changed so that when new curations are submitted, they are also immediately saved to the local cache.